### PR TITLE
Use before_action instead of before_filter

### DIFF
--- a/lib/weak_headers/controller.rb
+++ b/lib/weak_headers/controller.rb
@@ -4,7 +4,7 @@ module WeakHeaders
       filter_options = {}
       filter_options.merge!(only: args.flatten) unless args.empty?
 
-      before_filter filter_options do
+      before_action filter_options do
         validator = WeakHeaders::Validator.new(self, &block)
         WeakHeaders.stats[params[:controller]][params[:action]] = validator
         WeakHeaders.stats[params[:controller]][params[:action]].validate


### PR DESCRIPTION
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1
